### PR TITLE
Add Stick Man game prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # StickMan-Ai
-mea stickman generated with ai
+
+Basit bir Stick Man oyunu örneği. Python ve [Pygame](https://www.pygame.org/) kullanarak geliştirilmiştir.
+
+## Kurulum
+
+```bash
+pip install pygame
+```
+
+## Çalıştırma
+
+```bash
+python -m stickman.main
+```
+
+## Özellikler
+
+- Bölünerek çoğalan düşmanlar
+- Klavye ile kontrol edilen oyuncu
+- Basit silah ve eşya sistemi
+- 60 FPS oyun döngüsü

--- a/stickman/__init__.py
+++ b/stickman/__init__.py
@@ -1,0 +1,1 @@
+"""Stick Man oyunu paketi."""

--- a/stickman/enemy.py
+++ b/stickman/enemy.py
@@ -1,0 +1,41 @@
+import pygame
+from pygame.math import Vector2
+import random
+
+
+class Enemy:
+    def __init__(self, pos=None, stage=0):
+        self.pos = Vector2(pos or (random.randint(50, 750), random.randint(50, 550)))
+        self.stage = stage  # 0 original, 1 first split, 2 second split
+        self.speed = 120 + 20 * stage
+        self.radius = max(5, 20 - stage * 5)
+        self.color = (200, 50, 50)
+        self.time_alive = 0
+        self.dead = False
+
+    def update(self, dt):
+        self.time_alive += dt
+        direction = Vector2(400, 300) - self.pos
+        if direction.length() > 1:
+            direction = direction.normalize()
+        self.pos += direction * self.speed * dt
+
+        new_enemies = []
+        if self.time_alive >= 3 and self.stage < 2:
+            self.dead = True
+            if self.stage == 0:
+                new_enemies = [
+                    Enemy(self.pos + (10, 0), 1),
+                    Enemy(self.pos - (10, 0), 1),
+                ]
+            elif self.stage == 1:
+                new_enemies = [
+                    Enemy(self.pos + (10, 0), 2),
+                    Enemy(self.pos - (10, 0), 2),
+                    Enemy(self.pos + (0, 10), 2),
+                    Enemy(self.pos - (0, 10), 2),
+                ]
+        return new_enemies
+
+    def draw(self, surface):
+        pygame.draw.circle(surface, self.color, self.pos, self.radius)

--- a/stickman/item.py
+++ b/stickman/item.py
@@ -1,0 +1,11 @@
+class Item:
+    def __init__(self, name, effect, duration=0, cost=0):
+        self.name = name
+        self.effect = effect
+        self.duration = duration
+        self.cost = cost
+
+
+HEALTH_PACK = Item('Health', effect='heal', duration=0, cost=50)
+ARMOR = Item('Armor', effect='armor', duration=10, cost=75)
+INVINCIBILITY = Item('Invincibility', effect='invincible', duration=5, cost=150)

--- a/stickman/main.py
+++ b/stickman/main.py
@@ -1,0 +1,48 @@
+import pygame
+from .player import Player
+from .enemy import Enemy
+from pygame.locals import QUIT, KEYDOWN, K_ESCAPE
+
+
+def main():
+    pygame.init()
+    screen = pygame.display.set_mode((800, 600))
+    pygame.display.set_caption('Stick Man')
+    clock = pygame.time.Clock()
+
+    player = Player()
+    enemies = []
+    enemy_spawn_timer = 0
+
+    running = True
+    while running:
+        dt = clock.tick(60) / 1000.0
+        for event in pygame.event.get():
+            if event.type == QUIT or (event.type == KEYDOWN and event.key == K_ESCAPE):
+                running = False
+
+        # Spawn enemy every 2 seconds
+        enemy_spawn_timer += dt
+        if enemy_spawn_timer >= 2:
+            enemies.append(Enemy())
+            enemy_spawn_timer = 0
+
+        # Update
+        player.update(dt)
+        for enemy in enemies[:]:
+            enemy.update(dt)
+            if enemy.dead:
+                enemies.remove(enemy)
+
+        # Draw
+        screen.fill((30, 30, 30))
+        player.draw(screen)
+        for enemy in enemies:
+            enemy.draw(screen)
+        pygame.display.flip()
+
+    pygame.quit()
+
+
+if __name__ == '__main__':
+    main()

--- a/stickman/player.py
+++ b/stickman/player.py
@@ -1,0 +1,25 @@
+import pygame
+from pygame.math import Vector2
+
+
+class Player:
+    def __init__(self):
+        self.pos = Vector2(400, 300)
+        self.speed = 200
+        self.color = (200, 200, 200)
+        self.radius = 15
+        self.health = 100
+
+    def update(self, dt):
+        keys = pygame.key.get_pressed()
+        if keys[pygame.K_w]:
+            self.pos.y -= self.speed * dt
+        if keys[pygame.K_s]:
+            self.pos.y += self.speed * dt
+        if keys[pygame.K_a]:
+            self.pos.x -= self.speed * dt
+        if keys[pygame.K_d]:
+            self.pos.x += self.speed * dt
+
+    def draw(self, surface):
+        pygame.draw.circle(surface, self.color, self.pos, self.radius)

--- a/stickman/weapon.py
+++ b/stickman/weapon.py
@@ -1,0 +1,12 @@
+class Weapon:
+    def __init__(self, name, damage, cost=0):
+        self.name = name
+        self.damage = damage
+        self.cost = cost
+
+
+DEFAULT_WEAPONS = [
+    Weapon('Sword', 25, cost=0),
+    Weapon('Axe', 40, cost=100),
+    Weapon('Gun', 50, cost=200),
+]


### PR DESCRIPTION
## Summary
- add simple Pygame-based Stick Man game
- include player, enemy logic with splitting enemies
- provide minimal weapons and items
- document how to run the prototype

## Testing
- `python3 -m py_compile stickman/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685e6dd400488328ba6995d186545c15